### PR TITLE
Fixed some keys are empty.

### DIFF
--- a/src/serverconfighelper.cpp
+++ b/src/serverconfighelper.cpp
@@ -123,9 +123,9 @@ QStringList ServerConfigHelper::getV2RayStreamSettingsErrors(
   if (network == "ws") {
     errors.append(Utility::getStringConfigError(
       serverConfig, "networkHost", tr("Host"),
-      {std::bind(&Utility::isDomainNameValid, std::placeholders::_1)}));
+      {std::bind(&Utility::isDomainNameValid, std::placeholders::_1)}, true));
     errors.append(
-      Utility::getStringConfigError(serverConfig, "networkPath", tr("Path")));
+      Utility::getStringConfigError(serverConfig, "networkPath", tr("Path"), {}, true));
   }
   return errors;
 }
@@ -243,7 +243,7 @@ QJsonObject ServerConfigHelper::getV2RayServerConfigFromUrl(
     {"tcpHeaderType", rawServerConfig.contains("type")
                         ? rawServerConfig["type"].toString()
                         : ""},
-    {"networkSecurity", rawServerConfig.contains("tls") ? "tls" : "none"}};
+    {"networkSecurity", rawServerConfig.contains("tls") && !rawServerConfig["tls"].toString().isEmpty() ? "tls" : "none"}};
 
   return serverConfig;
 }


### PR DESCRIPTION
If the config has some keys which are empty or '', it will occur some error unexcepted. Such like V2ray config, tls, host, path, if these are empty, it should be none or ''.