### PR TITLE
Fixed set/get system proxy in Ubuntu

### DIFF
--- a/src/networkproxy.cpp
+++ b/src/networkproxy.cpp
@@ -14,9 +14,9 @@ NetworkProxy NetworkProxyHelper::getSystemProxy() {
 #elif defined(Q_OS_LINUX)
   QString desktopEnv =
     QProcessEnvironment::systemEnvironment().value("XDG_CURRENT_DESKTOP");
-  if (desktopEnv == "GNOME" || desktopEnv == "Unity") {
+  if (desktopEnv.contains("GNOME") || desktopEnv.contains("Unity")) {
     return getSystemProxyLinuxGnome();
-  } else if (desktopEnv == "KDE") {
+  } else if (desktopEnv.contains("KDE")) {
     return getSystemProxyLinuxKde();
   } else {
     return NetworkProxy();
@@ -34,9 +34,9 @@ void NetworkProxyHelper::setSystemProxy(const NetworkProxy& proxy) {
 #elif defined(Q_OS_LINUX)
   QString desktopEnv =
     QProcessEnvironment::systemEnvironment().value("XDG_CURRENT_DESKTOP");
-  if (desktopEnv == "GNOME" || desktopEnv == "Unity") {
+  if (desktopEnv.contains("GNOME") || desktopEnv.contains("Unity")) {
     return setSystemProxyLinuxGnome(proxy);
-  } else if (desktopEnv == "KDE") {
+  } else if (desktopEnv.contains("KDE")) {
     return setSystemProxyLinuxKde(proxy);
   }
 #endif
@@ -50,9 +50,9 @@ void NetworkProxyHelper::resetSystemProxy() {
 #elif defined(Q_OS_LINUX)
   QString desktopEnv =
     QProcessEnvironment::systemEnvironment().value("XDG_CURRENT_DESKTOP");
-  if (desktopEnv == "GNOME" || desktopEnv == "Unity") {
+  if (desktopEnv.contains("GNOME") || desktopEnv.contains("Unity")) {
     return resetSystemProxyLinuxGnome();
-  } else if (desktopEnv == "KDE") {
+  } else if (desktopEnv.contains("KDE")) {
     return resetSystemProxyLinuxKde();
   }
 #endif


### PR DESCRIPTION
hi, thank for such a nice project.
In Ubuntu 20.04, the system env about "XDG_CURRENT_DESKTOP" is shown as below:
```
XDG_CURRENT_DESKTOP=ubuntu:GNOME
```
therefore, we should use "Qstring.contains" rather than "==". 
https://github.com/Dr-Incognito/V2Ray-Desktop/blob/3d3c8aed27dc685de2ec246fef251fe2692ff665/src/networkproxy.cpp#L17
https://github.com/Dr-Incognito/V2Ray-Desktop/blob/3d3c8aed27dc685de2ec246fef251fe2692ff665/src/networkproxy.cpp#L37
https://github.com/Dr-Incognito/V2Ray-Desktop/blob/3d3c8aed27dc685de2ec246fef251fe2692ff665/src/networkproxy.cpp#L53